### PR TITLE
Fix depth generation logic and tests

### DIFF
--- a/relic_composer.py
+++ b/relic_composer.py
@@ -94,6 +94,11 @@ def decompose_albedo_shading(image: np.ndarray) -> tuple[np.ndarray, np.ndarray]
 
 # ------------------------------- Core Pipeline -------------------------------
 
+def _create_depth(image: np.ndarray, use_midas: bool) -> np.ndarray:
+    """Return a depth map using MiDaS if requested, else zeros."""
+    return generate_depth(image) if use_midas else np.zeros(image.shape[:2], dtype=np.uint8)
+
+
 def process_image(path: Path, out_dir: Path, args: argparse.Namespace) -> None:
     """Process a single image path."""
     image = load_image(path)
@@ -103,11 +108,11 @@ def process_image(path: Path, out_dir: Path, args: argparse.Namespace) -> None:
     albedo_path = out_dir / "passes" / f"{path.stem}_albedo.png"
     shading_path = out_dir / "passes" / f"{path.stem}_shading.png"
 
-    if args.use_midas and not depth_path.exists():
-        depth = generate_depth(image)
-        save_image(depth, depth_path)
+    if depth_path.exists():
+        depth = load_image(depth_path)
     else:
-        depth = load_image(depth_path) if depth_path.exists() else generate_depth(image)
+        depth = _create_depth(image, args.use_midas)
+        save_image(depth, depth_path)
 
     if not normal_path.exists():
         normal = depth_to_normal(depth)

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path as _P
+sys.path.append(str(_P(__file__).resolve().parents[1]))
+import argparse
+from pathlib import Path
+import numpy as np
+import cv2
+import relic_composer as rc
+
+
+def test_generate_alpha_binary(tmp_path):
+    img = np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)
+    mask = rc.generate_alpha(img)
+    unique = np.unique(mask)
+    assert set(unique).issubset({0, 255})
+
+def test_process_image_without_midas_skips_depth(monkeypatch, tmp_path):
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+    img_path = tmp_path / "input.png"
+    rc.save_image(img, img_path)
+
+    called = False
+
+    def fake_generate_depth(image):
+        nonlocal called
+        called = True
+        return np.zeros(image.shape[:2], dtype=np.uint8)
+
+    monkeypatch.setattr(rc, "generate_depth", fake_generate_depth)
+
+    args = argparse.Namespace(use_midas=False, alpha_model="u2net", use_iiwnet=False, triptych=False)
+
+    rc.process_image(img_path, tmp_path, args)
+
+    assert not called
+    assert (tmp_path / "passes" / "input_depth.png").exists()


### PR DESCRIPTION
## Summary
- avoid running MiDaS when `--use_midas` is not specified
- add helper for depth generation
- add basic unit tests for alpha mask and depth logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b948c4ba8833084cf792f31771138